### PR TITLE
Fixed double devise_for :users and restructured resources :products

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,21 +2,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
 
-  get 'products/index'
-
-  get 'products/new'
-
-  get 'products/create'
-
-  get 'products/show'
-
-  get 'products/edit'
-
-  get 'products/update'
-
-  get 'products/destroy'
-
-  devise_for :users
+  resources :products
 
   root to: 'pages#home'
   resources :users, only: [:show, :edit, :update]


### PR DESCRIPTION
There was a bug because of the double presence of devise_for :users.
Simplifies products routes
