### PR TITLE
Remove select on products_controller.rb

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -6,7 +6,7 @@ class ProductsController < ApplicationController
     @products = policy_scope(Product)
     if params[:product]
       @product_search = params[:product].downcase
-      @result = @products.select { |product| product.name.downcase.include?(@product_search) }
+      @result = @products.where(name: @product_search)
     end
   end
 


### PR DESCRIPTION
More efficient, the work is done by the DB and not by rails. But the seed needs to store the product names in downcase.
